### PR TITLE
Set iam_role to be optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_ecs_service" "ec2_service" {
   cluster                           = var.cluster
   desired_count                     = var.desired_count
   health_check_grace_period_seconds = var.attach_load_balancer ? var.healthcheck_grace_period : null
-  iam_role                          = aws_iam_role.service[0].arn
+  iam_role                          = var.attach_load_balancer ? aws_iam_role.service[0].arn : null
   task_definition                   = var.task_definition_arn
   launch_type                       = var.launch_type
   scheduling_strategy               = var.scheduling_strategy


### PR DESCRIPTION
From terraform doc: This parameter is required if you are using a load balancer with your service, but only if your task definition does not use the awsvpc network mode. If using awsvpc network mode, do not specify this role. If your account has already created the Amazon ECS service-linked role, that role is used by default for your service unless you specify a role here.